### PR TITLE
Fixes Omlet-Ltd/smartcoop-python-sdk#1: Added check for 204 to stop JSONDecodeError

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='smartcoop-python-sdk',
-    version='0.1.2',
+    version='0.1.3',
     packages=find_packages(),
     install_requires=[
         'requests',

--- a/smartcoop/client.py
+++ b/smartcoop/client.py
@@ -23,7 +23,8 @@ class SmartCoopClient:
         headers = self._get_headers()
         response = requests.post(url, headers=headers, json=json)
         response.raise_for_status()
-        return response.json()
+        if response.status_code != 204:
+            return response.json()
 
     def patch(self, endpoint, json=None):
         url = f'{self.base_url}/{endpoint}'


### PR DESCRIPTION
Hi,

This PR just ups the version and adds the check for the 204 to avoid the JSONDecodeError.