### PR TITLE
Improve logging and configuration payload handling

### DIFF
--- a/smartcoop/api/models/configuration.py
+++ b/smartcoop/api/models/configuration.py
@@ -28,11 +28,21 @@ class Configuration:
         )
 
     def to_json(self) -> dict:
-        return {
+        data = {
             "general": self.general.to_json(),
             "connectivity": self.connectivity.to_json(),
-            "door": self.door.to_json() if self.door else None,
-            "light": self.light.to_json() if self.light else None,
-            "feeder": self.feeder.to_json() if self.feeder else None,
-            "fan": self.fan.to_json if self.fan else None
         }
+
+        # Only include optional sub-configurations when present, rather than
+        # sending explicit nulls which may not be accepted by the backend.
+        if self.door is not None:
+            data["door"] = self.door.to_json()
+        if self.light is not None:
+            data["light"] = self.light.to_json()
+        if self.feeder is not None:
+            data["feeder"] = self.feeder.to_json()
+        if self.fan is not None:
+            # Note: fan implements to_json(), use the result not the function.
+            data["fan"] = self.fan.to_json()
+
+        return data

--- a/smartcoop/api/models/configuration_general.py
+++ b/smartcoop/api/models/configuration_general.py
@@ -32,16 +32,28 @@ class ConfigurationGeneral:
         )
 
     def to_json(self) -> dict:
-        return {
+        data = {
             "datetime": self.datetime,
             "timezone": self.timezone,
             "updateFrequency": self.updateFrequency,
-            "stayAliveTime": self.stayAliveTime,
-            "language": self.language,
-            "overnightSleepEnable": self.overnightSleepEnable,
-            "overnightSleepStart": self.overnightSleepStart,
-            "overnightSleepEnd": self.overnightSleepEnd,
-            "pollFreq": self.pollFreq,
             "statusUpdatePeriod": self.statusUpdatePeriod,
-            "useDst": self.useDst
         }
+
+        # Only include optional fields if they are explicitly set, to
+        # avoid sending JSON nulls that some backend versions reject.
+        if self.language is not None:
+            data["language"] = self.language
+        if self.overnightSleepEnable is not None:
+            data["overnightSleepEnable"] = self.overnightSleepEnable
+        if self.overnightSleepStart is not None:
+            data["overnightSleepStart"] = self.overnightSleepStart
+        if self.overnightSleepEnd is not None:
+            data["overnightSleepEnd"] = self.overnightSleepEnd
+        if self.pollFreq is not None:
+            data["pollFreq"] = self.pollFreq
+        if self.stayAliveTime is not None:
+            data["stayAliveTime"] = self.stayAliveTime
+        if self.useDst is not None:
+            data["useDst"] = self.useDst
+
+        return data

--- a/smartcoop/client.py
+++ b/smartcoop/client.py
@@ -1,4 +1,10 @@
+import logging
+
 import requests
+
+
+logger = logging.getLogger("smartcoop.client")
+
 
 class SmartCoopClient:
     def __init__(self, client_secret):
@@ -6,6 +12,7 @@ class SmartCoopClient:
         self.base_url = 'https://x107.omlet.co.uk/api/v1'
 
     def _get_headers(self):
+        # Do not log the Authorization header to avoid leaking secrets.
         return {
             'Authorization': f'Bearer {self.client_secret}',
             'Content-Type': 'application/json'
@@ -14,27 +21,68 @@ class SmartCoopClient:
     def get(self, endpoint, params=None):
         url = f'{self.base_url}/{endpoint}'
         headers = self._get_headers()
+        logger.debug("GET %s params=%s", url, params)
         response = requests.get(url, headers=headers, params=params)
-        response.raise_for_status()
+        try:
+            response.raise_for_status()
+        except requests.HTTPError:
+            logger.error(
+                "GET %s failed: status=%s, body=%s",
+                url,
+                response.status_code,
+                response.text,
+            )
+            raise
         return response.json()
 
     def post(self, endpoint, json=None):
         url = f'{self.base_url}/{endpoint}'
         headers = self._get_headers()
+        logger.debug("POST %s payload=%s", url, json)
         response = requests.post(url, headers=headers, json=json)
-        response.raise_for_status()
+        try:
+            response.raise_for_status()
+        except requests.HTTPError:
+            logger.error(
+                "POST %s failed: status=%s, body=%s, payload=%s",
+                url,
+                response.status_code,
+                response.text,
+                json,
+            )
+            raise
         if response.status_code != 204:
             return response.json()
 
     def patch(self, endpoint, json=None):
         url = f'{self.base_url}/{endpoint}'
         headers = self._get_headers()
+        logger.debug("PATCH %s payload=%s", url, json)
         response = requests.patch(url, headers=headers, json=json)
-        response.raise_for_status()
-
+        try:
+            response.raise_for_status()
+        except requests.HTTPError:
+            logger.error(
+                "PATCH %s failed: status=%s, body=%s, payload=%s",
+                url,
+                response.status_code,
+                response.text,
+                json,
+            )
+            raise
 
     def delete(self, endpoint):
         url = f'{self.base_url}/{endpoint}'
         headers = self._get_headers()
+        logger.debug("DELETE %s", url)
         response = requests.delete(url, headers=headers)
-        response.raise_for_status()
+        try:
+            response.raise_for_status()
+        except requests.HTTPError:
+            logger.error(
+                "DELETE %s failed: status=%s, body=%s",
+                url,
+                response.status_code,
+                response.text,
+            )
+            raise


### PR DESCRIPTION
NOTE: the debugging stuff below is certainly optional, but nice to have, however the empty payload makes the python sdk crash...

Add structured debug/error logging around all HTTP methods in SmartCoopClient to aid diagnosing API issues.

Adjust ConfigurationGeneral.to_json to only emit optional fields when set, avoiding sending nulls that some Omlet backends reject.

Update Configuration.to_json to omit None sub-configs and fix fan serialization to call to_json(), matching the payload shape that the API accepts.